### PR TITLE
Enable PDF

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -57,12 +57,11 @@
       "Pdf"
     ]
   },
-  "need_generate_pdf_url_template": false,
+  "need_generate_pdf_url_template": true,
   "need_generate_intellisense": false,
   "Targets": {
     "Pdf": {
       "template_folder": "_themes.pdf"
     }
-  },
-  "need_generate_pdf": false
+  }
 }


### PR DESCRIPTION
# I contributi pubblici non vengono accettati al momento

Questo archivio è stato reso pubblico per semplificare il download e l'utilizzo del contenuto per la creazione di soluzioni personalizzate della Guida.
Attualmente non si accettano contributi pubblici per l'archivio o il contenuto.
Se si desidera contribuire al contenuto pubblicato da Microsoft, passare a un archivio per la versione inglese in cui i contributi pubblici vengono elaborati.
